### PR TITLE
UNIX fixes + slight cleanup

### DIFF
--- a/UK Sound Replacement/Plugin.cs
+++ b/UK Sound Replacement/Plugin.cs
@@ -19,6 +19,8 @@ public class Plugin : UKMod
         //Assembly.Load(modFolder + "\\TagLibSharp.dll");
         harmony.PatchAll();
         SoundPackController.CreateNewSoundPack("Stock");
+        // Why does this essentially run twice? - Ali
+        /*
         Debug.Log("Searching " + Directory.GetCurrentDirectory() + " for .uksr files");
         //StartCoroutine(SoundPackController.LoadCgMusic(modFolder, this));
         foreach (FileInfo file in new DirectoryInfo(Directory.GetCurrentDirectory()).GetFiles("*.uksr", SearchOption.AllDirectories))
@@ -38,7 +40,7 @@ public class Plugin : UKMod
                 jFile.Close();
             }
         }
-
+		*/
 
         Debug.Log("Searching " + this.modFolder + " for .uksr files");
         //StartCoroutine(SoundPackController.LoadCgMusic(modFolder, this));

--- a/UK Sound Replacement/SoundPackController.cs
+++ b/UK Sound Replacement/SoundPackController.cs
@@ -251,8 +251,8 @@ public static class SoundPackController
     }
     private static IEnumerator StartNewWWWCg(string path, AudioType type, string introName, SoundtrackSong song)
     {
-
-        using (UnityWebRequest www = UnityWebRequestMultimedia.GetAudioClip(path, type))
+		// file:// is required for linux/mac - Ali
+        using (UnityWebRequest www = UnityWebRequestMultimedia.GetAudioClip("file://" + path, type))
         {
             yield return www.SendWebRequest();
 
@@ -495,7 +495,8 @@ public static class SoundPackController
 
             if (File.Exists(info.FullName + "/preview.png"))
             {
-                using (UnityWebRequest www = UnityWebRequestTexture.GetTexture(info.FullName + "/preview.png"))
+            	// file:// is required for linux/mac - Ali
+                using (UnityWebRequest www = UnityWebRequestTexture.GetTexture("file://" + info.FullName + "/preview.png"))
                 {
                     yield return www.SendWebRequest();
                     if (www.isNetworkError)
@@ -514,7 +515,8 @@ public static class SoundPackController
 
         private IEnumerator StartNewWWW(SoundAspect aspect, string soundUrl, AudioType type)
         {
-            using (UnityWebRequest www = UnityWebRequestMultimedia.GetAudioClip(soundUrl, type))
+        	// file:// is required for linux/mac - Ali
+            using (UnityWebRequest www = UnityWebRequestMultimedia.GetAudioClip("file://" + soundUrl, type))
             {
                 yield return www.SendWebRequest();
 

--- a/UK Sound Replacement/SoundPackController.cs
+++ b/UK Sound Replacement/SoundPackController.cs
@@ -33,159 +33,159 @@ public static class SoundPackController
         result.AddAspect(new SoundAspect("RailcannonChargedSounds", "RailcannonSounds", true, SoundPackType.Railcannon));
 
         // Blue
-        result.AddAspect(new SoundAspect("RailcannonClickSounds0", "RailcannonSounds\\RailcannonBlue", false, SoundPackType.Railcannon));
-        result.AddAspect(new SoundAspect("RailcannonIdleSounds0", "RailcannonSounds\\RailcannonBlue", false, SoundPackType.Railcannon));
-        result.AddAspect(new SoundAspect("RailcannonShootSounds0", "RailcannonSounds\\RailcannonBlue", false, SoundPackType.Railcannon));
-        result.AddAspect(new SoundAspect("RailcannonWhirSounds0", "RailcannonSounds\\RailcannonBlue", false, SoundPackType.Railcannon));
+        result.AddAspect(new SoundAspect("RailcannonClickSounds0", "RailcannonSounds/RailcannonBlue", false, SoundPackType.Railcannon));
+        result.AddAspect(new SoundAspect("RailcannonIdleSounds0", "RailcannonSounds/RailcannonBlue", false, SoundPackType.Railcannon));
+        result.AddAspect(new SoundAspect("RailcannonShootSounds0", "RailcannonSounds/RailcannonBlue", false, SoundPackType.Railcannon));
+        result.AddAspect(new SoundAspect("RailcannonWhirSounds0", "RailcannonSounds/RailcannonBlue", false, SoundPackType.Railcannon));
 
         // Green
-        result.AddAspect(new SoundAspect("RailcannonClickSounds1", "RailcannonSounds\\RailcannonGreen", false, SoundPackType.Railcannon));
-        result.AddAspect(new SoundAspect("RailcannonIdleSounds1", "RailcannonSounds\\RailcannonGreen", false, SoundPackType.Railcannon));
-        result.AddAspect(new SoundAspect("RailcannonShootSounds1", "RailcannonSounds\\RailcannonGreen", false, SoundPackType.Railcannon));
-        result.AddAspect(new SoundAspect("RailcannonWhirSounds1", "RailcannonSounds\\RailcannonGreen", false, SoundPackType.Railcannon));
+        result.AddAspect(new SoundAspect("RailcannonClickSounds1", "RailcannonSounds/RailcannonGreen", false, SoundPackType.Railcannon));
+        result.AddAspect(new SoundAspect("RailcannonIdleSounds1", "RailcannonSounds/RailcannonGreen", false, SoundPackType.Railcannon));
+        result.AddAspect(new SoundAspect("RailcannonShootSounds1", "RailcannonSounds/RailcannonGreen", false, SoundPackType.Railcannon));
+        result.AddAspect(new SoundAspect("RailcannonWhirSounds1", "RailcannonSounds/RailcannonGreen", false, SoundPackType.Railcannon));
 
         // Red
-        result.AddAspect(new SoundAspect("RailcannonClickSounds2", "RailcannonSounds\\RailcannonRed", false, SoundPackType.Railcannon));
-        result.AddAspect(new SoundAspect("RailcannonIdleSounds2", "RailcannonSounds\\RailcannonRed", false, SoundPackType.Railcannon));
-        result.AddAspect(new SoundAspect("RailcannonShootSounds2", "RailcannonSounds\\RailcannonRed", false, SoundPackType.Railcannon));
-        result.AddAspect(new SoundAspect("RailcannonRedWindDownSounds2", "RailcannonSounds\\RailcannonRed", false, SoundPackType.Railcannon));
-        result.AddAspect(new SoundAspect("RailcannonWhirSounds2", "RailcannonSounds\\RailcannonRed", false, SoundPackType.Railcannon));
+        result.AddAspect(new SoundAspect("RailcannonClickSounds2", "RailcannonSounds/RailcannonRed", false, SoundPackType.Railcannon));
+        result.AddAspect(new SoundAspect("RailcannonIdleSounds2", "RailcannonSounds/RailcannonRed", false, SoundPackType.Railcannon));
+        result.AddAspect(new SoundAspect("RailcannonShootSounds2", "RailcannonSounds/RailcannonRed", false, SoundPackType.Railcannon));
+        result.AddAspect(new SoundAspect("RailcannonRedWindDownSounds2", "RailcannonSounds/RailcannonRed", false, SoundPackType.Railcannon));
+        result.AddAspect(new SoundAspect("RailcannonWhirSounds2", "RailcannonSounds/RailcannonRed", false, SoundPackType.Railcannon));
 
         // Revolver
 
         // Blue
-        result.AddAspect(new SoundAspect("ChargeLoop0False", "ChargeLoop", "RevolverSounds\\RevolverPiercer", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("ChargeReady0False", "ChargeReady", "RevolverSounds\\RevolverPiercer", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("ChargingUp0False", "ChargingUp", "RevolverSounds\\RevolverPiercer", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("ClickCancel0False", "ClickCancel", "RevolverSounds\\RevolverPiercer", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("RevolverShootSounds0False", "ShootSounds", "RevolverSounds\\RevolverPiercer", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("RevolverSuperShootSounds0False", "SuperShootSounds", "RevolverSounds\\RevolverPiercer", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("ChargeLoop0False", "ChargeLoop", "RevolverSounds/RevolverPiercer", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("ChargeReady0False", "ChargeReady", "RevolverSounds/RevolverPiercer", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("ChargingUp0False", "ChargingUp", "RevolverSounds/RevolverPiercer", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("ClickCancel0False", "ClickCancel", "RevolverSounds/RevolverPiercer", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("RevolverShootSounds0False", "ShootSounds", "RevolverSounds/RevolverPiercer", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("RevolverSuperShootSounds0False", "SuperShootSounds", "RevolverSounds/RevolverPiercer", SoundPackType.Revolver));
 
         // Blue alt
-        result.AddAspect(new SoundAspect("ChargeLoop0True", "ChargeLoop", "RevolverSounds\\RevolverPiercerAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("ChargeReady0True", "ChargeReady", "RevolverSounds\\RevolverPiercerAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("ChargingUp0True", "ChargingUp", "RevolverSounds\\RevolverPiercerAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("ClickCancel0True", "ClickCancel", "RevolverSounds\\RevolverPiercerAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("RevolverShootSounds0True", "ShootSounds", "RevolverSounds\\RevolverPiercerAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("RevolverSuperShootSounds0True", "SuperShootSounds", "RevolverSounds\\RevolverPiercerAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("HammerClick0", "HammerClick", "RevolverSounds\\RevolverPiercerAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("ChargeLoop0True", "ChargeLoop", "RevolverSounds/RevolverPiercerAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("ChargeReady0True", "ChargeReady", "RevolverSounds/RevolverPiercerAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("ChargingUp0True", "ChargingUp", "RevolverSounds/RevolverPiercerAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("ClickCancel0True", "ClickCancel", "RevolverSounds/RevolverPiercerAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("RevolverShootSounds0True", "ShootSounds", "RevolverSounds/RevolverPiercerAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("RevolverSuperShootSounds0True", "SuperShootSounds", "RevolverSounds/RevolverPiercerAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("HammerClick0", "HammerClick", "RevolverSounds/RevolverPiercerAlt", SoundPackType.Revolver));
 
         // Green
-        result.AddAspect(new SoundAspect("CoinBreak1False", "CoinTwirl", "RevolverSounds\\RevolverMarksman", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("CoinFlashLoop1False", "CoinFlashLoop", "RevolverSounds\\RevolverMarksman", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("CoinFlip1False", "CoinFlip", "RevolverSounds\\RevolverMarksman", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("CoinReady1False", "CoinReady", "RevolverSounds\\RevolverMarksman", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("CoinSpin1False", "CoinSpin", "RevolverSounds\\RevolverMarksman", SoundPackType.Revolver));
-        //result.AddAspect(new SoundAspect("CoinTwirl1False", "CoinTwirl", "RevolverSounds\\RevolverMarksman"));
-        result.AddAspect(new SoundAspect("CoinRicochet1False", "Ricochet", "RevolverSounds\\RevolverMarksman", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("RevolverShootSounds1False", "ShootSounds", "RevolverSounds\\RevolverMarksman", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("CoinBreak1False", "CoinTwirl", "RevolverSounds/RevolverMarksman", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("CoinFlashLoop1False", "CoinFlashLoop", "RevolverSounds/RevolverMarksman", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("CoinFlip1False", "CoinFlip", "RevolverSounds/RevolverMarksman", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("CoinReady1False", "CoinReady", "RevolverSounds/RevolverMarksman", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("CoinSpin1False", "CoinSpin", "RevolverSounds/RevolverMarksman", SoundPackType.Revolver));
+        //result.AddAspect(new SoundAspect("CoinTwirl1False", "CoinTwirl", "RevolverSounds/RevolverMarksman"));
+        result.AddAspect(new SoundAspect("CoinRicochet1False", "Ricochet", "RevolverSounds/RevolverMarksman", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("RevolverShootSounds1False", "ShootSounds", "RevolverSounds/RevolverMarksman", SoundPackType.Revolver));
 
         // Green alt
-        result.AddAspect(new SoundAspect("CoinBreak1True", "CoinTwirl", "RevolverSounds\\RevolverMarksmanAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("CoinFlashLoop1True", "CoinFlashLoop", "RevolverSounds\\RevolverMarksmanAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("CoinFlip1True", "CoinFlip", "RevolverSounds\\RevolverMarksmanAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("CoinReady1True", "CoinReady", "RevolverSounds\\RevolverMarksmanAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("CoinSpin1True", "CoinSpin", "RevolverSounds\\RevolverMarksmanAlt", SoundPackType.Revolver));
-        //result.AddAspect(new SoundAspect("CoinTwirl1True", "CoinTwirl", "RevolverSounds\\RevolverMarksmanAlt"));
-        result.AddAspect(new SoundAspect("CoinRicochet1True", "Ricochet", "RevolverSounds\\RevolverMarksmanAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("RevolverShootSounds1True", "ShootSounds", "RevolverSounds\\RevolverMarksmanAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("HammerClick1", "HammerClick", "RevolverSounds\\RevolverMarksmanAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("CoinBreak1True", "CoinTwirl", "RevolverSounds/RevolverMarksmanAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("CoinFlashLoop1True", "CoinFlashLoop", "RevolverSounds/RevolverMarksmanAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("CoinFlip1True", "CoinFlip", "RevolverSounds/RevolverMarksmanAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("CoinReady1True", "CoinReady", "RevolverSounds/RevolverMarksmanAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("CoinSpin1True", "CoinSpin", "RevolverSounds/RevolverMarksmanAlt", SoundPackType.Revolver));
+        //result.AddAspect(new SoundAspect("CoinTwirl1True", "CoinTwirl", "RevolverSounds/RevolverMarksmanAlt"));
+        result.AddAspect(new SoundAspect("CoinRicochet1True", "Ricochet", "RevolverSounds/RevolverMarksmanAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("RevolverShootSounds1True", "ShootSounds", "RevolverSounds/RevolverMarksmanAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("HammerClick1", "HammerClick", "RevolverSounds/RevolverMarksmanAlt", SoundPackType.Revolver));
 
         // Red
-        result.AddAspect(new SoundAspect("RevolverShootSounds2False", "ShootSounds", "RevolverSounds\\RevolverSharpshooter", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("RevolverSuperShootSounds2False", "SuperShootSounds", "RevolverSounds\\RevolverSharpshooter", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("TwirlChargedFalse", "TwirlCharged", "RevolverSounds\\RevolverSharpshooter", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("TwirlSoundFalse", "TwirlSound", "RevolverSounds\\RevolverSharpshooter", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("RevolverShootSounds2False", "ShootSounds", "RevolverSounds/RevolverSharpshooter", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("RevolverSuperShootSounds2False", "SuperShootSounds", "RevolverSounds/RevolverSharpshooter", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("TwirlChargedFalse", "TwirlCharged", "RevolverSounds/RevolverSharpshooter", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("TwirlSoundFalse", "TwirlSound", "RevolverSounds/RevolverSharpshooter", SoundPackType.Revolver));
 
         // Red alt
-        result.AddAspect(new SoundAspect("RevolverShootSounds2True", "ShootSounds", "RevolverSounds\\RevolverSharpshooterAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("RevolverSuperShootSounds2True", "SuperShootSounds", "RevolverSounds\\RevolverSharpshooterAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("TwirlChargedTrue", "TwirlCharged", "RevolverSounds\\RevolverSharpshooterAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("TwirlSoundTrue", "TwirlSound", "RevolverSounds\\RevolverSharpshooterAlt", SoundPackType.Revolver));
-        result.AddAspect(new SoundAspect("HammerClick2", "HammerClick", "RevolverSounds\\RevolverSharpshooterAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("RevolverShootSounds2True", "ShootSounds", "RevolverSounds/RevolverSharpshooterAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("RevolverSuperShootSounds2True", "SuperShootSounds", "RevolverSounds/RevolverSharpshooterAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("TwirlChargedTrue", "TwirlCharged", "RevolverSounds/RevolverSharpshooterAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("TwirlSoundTrue", "TwirlSound", "RevolverSounds/RevolverSharpshooterAlt", SoundPackType.Revolver));
+        result.AddAspect(new SoundAspect("HammerClick2", "HammerClick", "RevolverSounds/RevolverSharpshooterAlt", SoundPackType.Revolver));
 
         // Shotgun
 
         // Blue
-        result.AddAspect(new SoundAspect("ShotgunShootSounds0", "ShotgunShootSounds", "ShotgunSounds\\ShotgunBlue", SoundPackType.Shotgun));
-        result.AddAspect(new SoundAspect("ShotgunChargeLoop", "ChargeLoop", "ShotgunSounds\\ShotgunBlue", SoundPackType.Shotgun));
-        result.AddAspect(new SoundAspect("CoreEject", "ShotgunSounds\\ShotgunBlue", true, SoundPackType.Shotgun));
-        result.AddAspect(new SoundAspect("CoreEjectFlick", "ShotgunSounds\\ShotgunBlue", true, SoundPackType.Shotgun));
-        result.AddAspect(new SoundAspect("CoreEjectReload", "ShotgunSounds\\ShotgunBlue", true, SoundPackType.Shotgun));
-        result.AddAspect(new SoundAspect("MainShotReload", "ShotgunSounds\\ShotgunBlue", true, SoundPackType.Shotgun));
-        result.AddAspect(new SoundAspect("HeatHiss", "ShotgunSounds\\ShotgunBlue", true, SoundPackType.Shotgun));
+        result.AddAspect(new SoundAspect("ShotgunShootSounds0", "ShotgunShootSounds", "ShotgunSounds/ShotgunBlue", SoundPackType.Shotgun));
+        result.AddAspect(new SoundAspect("ShotgunChargeLoop", "ChargeLoop", "ShotgunSounds/ShotgunBlue", SoundPackType.Shotgun));
+        result.AddAspect(new SoundAspect("CoreEject", "ShotgunSounds/ShotgunBlue", true, SoundPackType.Shotgun));
+        result.AddAspect(new SoundAspect("CoreEjectFlick", "ShotgunSounds/ShotgunBlue", true, SoundPackType.Shotgun));
+        result.AddAspect(new SoundAspect("CoreEjectReload", "ShotgunSounds/ShotgunBlue", true, SoundPackType.Shotgun));
+        result.AddAspect(new SoundAspect("MainShotReload", "ShotgunSounds/ShotgunBlue", true, SoundPackType.Shotgun));
+        result.AddAspect(new SoundAspect("HeatHiss", "ShotgunSounds/ShotgunBlue", true, SoundPackType.Shotgun));
 
         // Green
-        result.AddAspect(new SoundAspect("ShotgunShootSounds1", "ShotgunShootSounds", "ShotgunSounds\\ShotgunGreen", SoundPackType.Shotgun));
-        result.AddAspect(new SoundAspect("ShotgunCharge", "ShotgunSounds\\ShotgunGreen", true, SoundPackType.Shotgun));
-        result.AddAspect(new SoundAspect("ShotgunPump1", "ShotgunSounds\\ShotgunGreen", true, SoundPackType.Shotgun));
-        result.AddAspect(new SoundAspect("ShotgunPump2", "ShotgunSounds\\ShotgunGreen", true, SoundPackType.Shotgun));
-        result.AddAspect(new SoundAspect("OverCharged", "ShotgunSounds\\ShotgunGreen", true, SoundPackType.Shotgun));
+        result.AddAspect(new SoundAspect("ShotgunShootSounds1", "ShotgunShootSounds", "ShotgunSounds/ShotgunGreen", SoundPackType.Shotgun));
+        result.AddAspect(new SoundAspect("ShotgunCharge", "ShotgunSounds/ShotgunGreen", true, SoundPackType.Shotgun));
+        result.AddAspect(new SoundAspect("ShotgunPump1", "ShotgunSounds/ShotgunGreen", true, SoundPackType.Shotgun));
+        result.AddAspect(new SoundAspect("ShotgunPump2", "ShotgunSounds/ShotgunGreen", true, SoundPackType.Shotgun));
+        result.AddAspect(new SoundAspect("OverCharged", "ShotgunSounds/ShotgunGreen", true, SoundPackType.Shotgun));
 
         // Nailgun
 
         // Blue
-        result.AddAspect(new SoundAspect("BarrelSpin1False", "BarrelSpin", "NailgunSounds\\NailgunBlue", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NailgunLastShot1False", "NailgunLastShot", "NailgunSounds\\NailgunBlue", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NailgunShot1False", "NailgunShot", "NailgunSounds\\NailgunBlue", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NewCharge1False", "NewCharge", "NailgunSounds\\NailgunBlue", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NoAmmoClick1False", "NoAmmoClick", "NailgunSounds\\NailgunBlue", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("MagnetBeep1False", "MagnetBeep", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("MagnetBreak1False", "MagnetBreak", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("MagnetHit1False", "MagnetHit", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("MagnetHitEnemy1False", "MagnetHitEnemy", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NailZap1False", "NailZap", "NailgunSounds\\NailgunBlue", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("HeatSteam1False", "HeatSteam", "NailgunSounds\\NailgunBlue", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("BarrelSpin1False", "BarrelSpin", "NailgunSounds/NailgunBlue", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NailgunLastShot1False", "NailgunLastShot", "NailgunSounds/NailgunBlue", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NailgunShot1False", "NailgunShot", "NailgunSounds/NailgunBlue", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NewCharge1False", "NewCharge", "NailgunSounds/NailgunBlue", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NoAmmoClick1False", "NoAmmoClick", "NailgunSounds/NailgunBlue", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("MagnetBeep1False", "MagnetBeep", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("MagnetBreak1False", "MagnetBreak", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("MagnetHit1False", "MagnetHit", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("MagnetHitEnemy1False", "MagnetHitEnemy", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NailZap1False", "NailZap", "NailgunSounds/NailgunBlue", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("HeatSteam1False", "HeatSteam", "NailgunSounds/NailgunBlue", SoundPackType.Nailgun));
 
         // Blue alt
-        result.AddAspect(new SoundAspect("MagnetBeep1True", "MagnetBeep", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("MagnetBreak1True", "MagnetBreak", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("MagnetHit1True", "MagnetHit", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("MagnetHitEnemy1True", "MagnetHitEnemy", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("BarrelSpin1True", "BarrelSpin", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NailgunLastShot1True", "NailgunLastShot", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NailgunShot1True", "NailgunShot", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NailgunSnap1True", "NailgunSnap", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NewCharge1True", "NewCharge", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NoAmmoClick1True", "NoAmmoClick", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("SawBreak1True", "SawBreak", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("SawBounce1True", "SawBounce", "NailgunSounds\\NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("MagnetBeep1True", "MagnetBeep", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("MagnetBreak1True", "MagnetBreak", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("MagnetHit1True", "MagnetHit", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("MagnetHitEnemy1True", "MagnetHitEnemy", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("BarrelSpin1True", "BarrelSpin", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NailgunLastShot1True", "NailgunLastShot", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NailgunShot1True", "NailgunShot", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NailgunSnap1True", "NailgunSnap", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NewCharge1True", "NewCharge", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NoAmmoClick1True", "NoAmmoClick", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("SawBreak1True", "SawBreak", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("SawBounce1True", "SawBounce", "NailgunSounds/NailgunBlueAlt", SoundPackType.Nailgun));
 
         // Green
-        result.AddAspect(new SoundAspect("BarrelSpin0False", "BarrelSpin", "NailgunSounds\\NailgunGreen", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NailgunShot0False", "NailgunShot", "NailgunSounds\\NailgunGreen", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NewCharge0False", "NewCharge", "NailgunSounds\\NailgunGreen", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NailgunShotOverheat0False", "NailgunShotOverheat", "NailgunSounds\\NailgunGreen", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NailZap0False", "NailZap", "NailgunSounds\\NailgunGreen", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("HeatSteam0False", "HeatSteam", "NailgunSounds\\NailgunGreen", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("BarrelSpin0False", "BarrelSpin", "NailgunSounds/NailgunGreen", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NailgunShot0False", "NailgunShot", "NailgunSounds/NailgunGreen", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NewCharge0False", "NewCharge", "NailgunSounds/NailgunGreen", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NailgunShotOverheat0False", "NailgunShotOverheat", "NailgunSounds/NailgunGreen", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NailZap0False", "NailZap", "NailgunSounds/NailgunGreen", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("HeatSteam0False", "HeatSteam", "NailgunSounds/NailgunGreen", SoundPackType.Nailgun));
 
         // Green alt
-        result.AddAspect(new SoundAspect("BarrelSpin0True", "BarrelSpin", "NailgunSounds\\NailgunGreenAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NailgunShot0True", "NailgunShot", "NailgunSounds\\NailgunGreenAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NailgunSnap0True", "NailgunSnap", "NailgunSounds\\NailgunGreenAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NewCharge0True", "NewCharge", "NailgunSounds\\NailgunGreenAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("NailgunShotOverheat0True", "NailgunShotOverheat", "NailgunSounds\\NailgunGreenAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("SawBreak0True", "SawBreak", "NailgunSounds\\NailgunGreenAlt", SoundPackType.Nailgun));
-        result.AddAspect(new SoundAspect("SawBounce0True", "SawBounce", "NailgunSounds\\NailgunGreenAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("BarrelSpin0True", "BarrelSpin", "NailgunSounds/NailgunGreenAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NailgunShot0True", "NailgunShot", "NailgunSounds/NailgunGreenAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NailgunSnap0True", "NailgunSnap", "NailgunSounds/NailgunGreenAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NewCharge0True", "NewCharge", "NailgunSounds/NailgunGreenAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("NailgunShotOverheat0True", "NailgunShotOverheat", "NailgunSounds/NailgunGreenAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("SawBreak0True", "SawBreak", "NailgunSounds/NailgunGreenAlt", SoundPackType.Nailgun));
+        result.AddAspect(new SoundAspect("SawBounce0True", "SawBounce", "NailgunSounds/NailgunGreenAlt", SoundPackType.Nailgun));
 
 
         // Rocket Launcher blue
-        result.AddAspect(new SoundAspect("RocketLauncherClunkSounds0", "RocketLauncherClunkSounds", "RocketLauncherSounds\\RocketLauncherBlue", SoundPackType.RocketLauncher));
-        result.AddAspect(new SoundAspect("RocketLauncherExhaustSounds0", "RocketLauncherExhaustSounds", "RocketLauncherSounds\\RocketLauncherBlue", SoundPackType.RocketLauncher));
-        result.AddAspect(new SoundAspect("RocketLauncherFreezeSounds", "RocketLauncherFreezeSounds", "RocketLauncherSounds\\RocketLauncherBlue", SoundPackType.RocketLauncher));
-        result.AddAspect(new SoundAspect("RocketLauncherShootSounds0", "RocketLauncherShootSounds", "RocketLauncherSounds\\RocketLauncherBlue", SoundPackType.RocketLauncher));
-        result.AddAspect(new SoundAspect("RocketLauncherTickSounds", "RocketLauncherTickSounds", "RocketLauncherSounds\\RocketLauncherBlue", SoundPackType.RocketLauncher));
-        result.AddAspect(new SoundAspect("RocketLauncherUnfreezeSounds", "RocketLauncherUnfreezeSounds", "RocketLauncherSounds\\RocketLauncherBlue", SoundPackType.RocketLauncher));
-        result.AddAspect(new SoundAspect("RocketLauncherWindUpSounds", "RocketLauncherWindUpSounds", "RocketLauncherSounds\\RocketLauncherBlue", SoundPackType.RocketLauncher));
+        result.AddAspect(new SoundAspect("RocketLauncherClunkSounds0", "RocketLauncherClunkSounds", "RocketLauncherSounds/RocketLauncherBlue", SoundPackType.RocketLauncher));
+        result.AddAspect(new SoundAspect("RocketLauncherExhaustSounds0", "RocketLauncherExhaustSounds", "RocketLauncherSounds/RocketLauncherBlue", SoundPackType.RocketLauncher));
+        result.AddAspect(new SoundAspect("RocketLauncherFreezeSounds", "RocketLauncherFreezeSounds", "RocketLauncherSounds/RocketLauncherBlue", SoundPackType.RocketLauncher));
+        result.AddAspect(new SoundAspect("RocketLauncherShootSounds0", "RocketLauncherShootSounds", "RocketLauncherSounds/RocketLauncherBlue", SoundPackType.RocketLauncher));
+        result.AddAspect(new SoundAspect("RocketLauncherTickSounds", "RocketLauncherTickSounds", "RocketLauncherSounds/RocketLauncherBlue", SoundPackType.RocketLauncher));
+        result.AddAspect(new SoundAspect("RocketLauncherUnfreezeSounds", "RocketLauncherUnfreezeSounds", "RocketLauncherSounds/RocketLauncherBlue", SoundPackType.RocketLauncher));
+        result.AddAspect(new SoundAspect("RocketLauncherWindUpSounds", "RocketLauncherWindUpSounds", "RocketLauncherSounds/RocketLauncherBlue", SoundPackType.RocketLauncher));
 
         // Rocket Launcher Green
-        result.AddAspect(new SoundAspect("RocketLauncherClunkSounds1", "RocketLauncherClunkSounds", "RocketLauncherSounds\\RocketLauncherGreen", SoundPackType.RocketLauncher));
-        result.AddAspect(new SoundAspect("RocketLauncherExhaustSounds1", "RocketLauncherExhaustSounds", "RocketLauncherSounds\\RocketLauncherGreen", SoundPackType.RocketLauncher));
-        result.AddAspect(new SoundAspect("RocketLauncherShootSounds1", "RocketLauncherShootSounds", "RocketLauncherSounds\\RocketLauncherGreen", SoundPackType.RocketLauncher));
-        result.AddAspect(new SoundAspect("RocketLauncherCannonballShootSounds", "RocketLauncherCannonballShootSounds", "RocketLauncherSounds\\RocketLauncherGreen", SoundPackType.RocketLauncher));
-        result.AddAspect(new SoundAspect("RocketLauncherCannonballChargeUp", "RocketLauncherCannonballChargeUp", "RocketLauncherSounds\\RocketLauncherGreen", SoundPackType.RocketLauncher));
-        result.AddAspect(new SoundAspect("RocketLauncherCannonballTimerWindUp", "RocketLauncherCannonballTimerWindUp", "RocketLauncherSounds\\RocketLauncherGreen", SoundPackType.RocketLauncher));
-        result.AddAspect(new SoundAspect("RocketLauncherCannonballBounce", "RocketLauncherCannonballBounce", "RocketLauncherSounds\\RocketLauncherGreen", SoundPackType.RocketLauncher));
+        result.AddAspect(new SoundAspect("RocketLauncherClunkSounds1", "RocketLauncherClunkSounds", "RocketLauncherSounds/RocketLauncherGreen", SoundPackType.RocketLauncher));
+        result.AddAspect(new SoundAspect("RocketLauncherExhaustSounds1", "RocketLauncherExhaustSounds", "RocketLauncherSounds/RocketLauncherGreen", SoundPackType.RocketLauncher));
+        result.AddAspect(new SoundAspect("RocketLauncherShootSounds1", "RocketLauncherShootSounds", "RocketLauncherSounds/RocketLauncherGreen", SoundPackType.RocketLauncher));
+        result.AddAspect(new SoundAspect("RocketLauncherCannonballShootSounds", "RocketLauncherCannonballShootSounds", "RocketLauncherSounds/RocketLauncherGreen", SoundPackType.RocketLauncher));
+        result.AddAspect(new SoundAspect("RocketLauncherCannonballChargeUp", "RocketLauncherCannonballChargeUp", "RocketLauncherSounds/RocketLauncherGreen", SoundPackType.RocketLauncher));
+        result.AddAspect(new SoundAspect("RocketLauncherCannonballTimerWindUp", "RocketLauncherCannonballTimerWindUp", "RocketLauncherSounds/RocketLauncherGreen", SoundPackType.RocketLauncher));
+        result.AddAspect(new SoundAspect("RocketLauncherCannonballBounce", "RocketLauncherCannonballBounce", "RocketLauncherSounds/RocketLauncherGreen", SoundPackType.RocketLauncher));
 
 
         allSoundPacks.Add(name, result);
@@ -208,7 +208,7 @@ public static class SoundPackController
 
         foreach (DirectoryInfo subdirectory in info.GetDirectories())
         {
-            FileInfo fInfo = new FileInfo(subdirectory.FullName + "\\song.json");
+            FileInfo fInfo = new FileInfo(subdirectory.FullName + "/song.json");
             if (!fInfo.Exists)
                 continue;
             // convert fInfo json file into a dictionary
@@ -279,7 +279,7 @@ public static class SoundPackController
         if (persistentIntroName == "Random")
         {
             int random = Random.Range(0, cgMusicIntro.Count + 1);
-            if (random != cgMusicIntro.Count)  // accounting for stock song
+            if (random != cgMusicIntro.Count)  / accounting for stock song
                 source.clip = cgMusicIntro[random].clip;
         }
         else if (persistentIntroName == "Stock")
@@ -493,14 +493,14 @@ public static class SoundPackController
                     Debug.Log("Couldn't find " + info.FullName + aspect.path);
             }
 
-            if (File.Exists(info.FullName + "\\preview.png"))
+            if (File.Exists(info.FullName + "/preview.png"))
             {
-                using (UnityWebRequest www = UnityWebRequestTexture.GetTexture(info.FullName + "\\preview.png"))
+                using (UnityWebRequest www = UnityWebRequestTexture.GetTexture(info.FullName + "/preview.png"))
                 {
                     yield return www.SendWebRequest();
                     if (www.isNetworkError)
                     {
-                        Debug.Log("couldn't load preview image " + info.FullName + "\\preview.png");
+                        Debug.Log("couldn't load preview image " + info.FullName + "/preview.png");
                         Debug.Log(www.error);
                     }
                     else
@@ -601,16 +601,16 @@ public static class SoundPackController
             this.name = name;
             this.type = type;
             if (useSameName)
-                this.path = "\\" + path + "\\" + name + "\\";
+                this.path = "/" + path + "/" + name + "/";
             else
-                this.path = "\\" + path + "\\" + name.Substring(0, name.Length - 1) + "\\";
+                this.path = "/" + path + "/" + name.Substring(0, name.Length - 1) + "/";
         }
 
         public SoundAspect(string name, string folderName, string path, SoundPackType type)
         {
             this.name = name;
             this.type = type;
-            this.path = "\\" + path + "\\" + folderName + "\\";
+            this.path = "/" + path + "/" + folderName + "/";
         }
     }
 
@@ -621,7 +621,7 @@ public static class SoundPackController
         public Texture2D image;
         public bool isLoop;
 
-        public ClipData(FileInfo info, AudioClip clip, bool isLoop) // thanks https://answers.unity.com/questions/1461776/how-can-i-access-metadata-from-mp3-such-as-artist.html
+        public ClipData(FileInfo info, AudioClip clip, bool isLoop) // thanks https://answers.unity.com/questions/1\461776/how-can-i-access-metadata-from-mp3-such-as-artist.html
         {
             this.clip = clip;
             this.isLoop = isLoop;

--- a/UK Sound Replacement/UK Sound Replacement.csproj
+++ b/UK Sound Replacement/UK Sound Replacement.csproj
@@ -32,15 +32,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\BepInEx\core\0Harmony.dll</HintPath>
+      <HintPath>$(BepInExCoreDir)\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(ManagedDir)\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(ManagedDir)\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -50,57 +50,57 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="TagLibSharp, Version=2.3.0.0, Culture=neutral, PublicKeyToken=db62eba44689b5b0, processorArchitecture=MSIL">
-      <HintPath>..\packages\TagLibSharp.2.3.0\lib\net462\TagLibSharp.dll</HintPath>
+    <Reference Include="TagLibSharp, Version=2.4.0.0, Culture=neutral, PublicKeyToken=db62eba44689b5b0, processorArchitecture=MSIL">
+      <HintPath>TagLibSharp.dll</HintPath>
     </Reference>
     <Reference Include="UMM">
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\BepInEx\plugins\UMM\UMM.dll</HintPath>
+      <HintPath>$(BepInExPluginsDir)\UMM\UMM.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.AssetBundleModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.AudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.ParticleSystemModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.UIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAssetBundleModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.UnityWebRequestModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestTextureModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestWWWModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -123,11 +123,15 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>IF EXIST "D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\" (
-    copy "$(TargetPath)" "D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\BepInEx\UMM Mods\UKSoundReplacement\UKSoundReplacement.dll"
-)
-IF EXIST "C:\Program Files (x86)\Steam\steamapps\common\ULTRAKILL\BepInEx\UMM Mods\UKSoundReplacement" (
-    copy "$(TargetPath)" "C:\Program Files (x86)\Steam\steamapps\common\ULTRAKILL\BepInEx\UMM Mods\UKSoundReplacement\UKSoundReplacement.dll"
-)</PostBuildEvent>
+    <ManagedDir>$(ULTRAKILLPath)/ULTRAKILL_Data/Managed/</ManagedDir>
+    <BepInExRootDir>$(ULTRAKILLPath)/BepInEx/</BepInExRootDir>
+    <BepInExCoreDir>$(BepInExRootDir)/core/</BepInExCoreDir>
+    <BepInExPluginsDir>$(BepInExRootDir)/plugins/</BepInExPluginsDir>
   </PropertyGroup>
+  <Target Name="WarnBeforeBuild" BeforeTargets="BeforeBuild">
+    <Error Condition="!Exists($(ULTRAKILLPath))" Text="ULTRAKILLPath not set, create a .csproj.user file that sets this property to compile" />
+  </Target>
+  <Target Name="CopyModDlls" AfterTargets="AfterBuild">
+    <Copy SourceFiles="$(OutDir)/$(AssemblyName).dll" DestinationFolder="$(BepInExRootDir)/UMM Mods/UKSoundReplacement/" />
+  </Target>
 </Project>


### PR DESCRIPTION
- Fix filepaths using the Windows directory separator character "\"
- Make the csproj file easier to build on any machine, set $(ULTRAKILLPath) to your ULTRAKILL directory
- [Fix UnityWebRequest failing to load local files on Linux/MacOS](https://discussions.unity.com/t/unitywebrequest-fails-to-load-local-files-on-linux-mac/252913)
- Fix soundpacks being loaded twice, fixing an error